### PR TITLE
Add supported editors to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # SelectScriptC
+
 SelectScript Compiler and REPL implemented in Clojure and the SandhillSkipperVM
+
+## Editor Integration
+
+There is syntax highlighting support for several editors available:
+
+| Atom  | [github.com/ESS-OVGU/language-selectscript](https://github.com/ESS-OVGU/language-selectscript) |
+|-------|------------------------------------------------------------------------------------------------|
+| Emacs | [github.com/fin-ger/select-script-mode](https://github.com/fin-ger/select-script-mode)         |


### PR DESCRIPTION
This commit adds a list of supported editors to the README to minimize the time for newcomers to get started with selectscript.
